### PR TITLE
Only use toDate() if todaysFirstTick is not null

### DIFF
--- a/src/models/Wikifolio.ts
+++ b/src/models/Wikifolio.ts
@@ -646,7 +646,7 @@ export class Wikifolio {
 			data.dates = data.timestamps.map(ts => toDate(ts))
 			data.creationDate = toDate(data.creationDate)
 			data.publishDate = toDate(data.publishDate)
-			data.todaysFirstTick = toDate(data.todaysFirstTick)
+			data.todaysFirstTick = !data.todaysFirstTick ?? toDate(data.todaysFirstTick)
 		}
 
 		return data


### PR DESCRIPTION
If the intraday data is not yet available, the variable todaysFirstTick is null. The function history() in Wikifolio.ts tries to set 
```this.todaysFirstTick = toDate(data.todaysFirstTick)``` which leads to an error in toDate() in utils.ts because of ```val.includes('T')``` where val is null.

![image](https://user-images.githubusercontent.com/55323459/131216155-4b2bbeb4-1366-4c03-ad38-05275cf1e8b5.png)

If the XML result of the api call https://www.wikifolio.com/api/chart/{UUID}/indexhistory has no value for TodaysFirstTick, it will look like this:

```xml
<TodaysFirstTick i:nil="true"/>
```

```shell
(node:13044) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'includes' of null
    at Object.toDate (C:\Users\XXX\Desktop\wikifolio\src\utils.ts:53:9)
    at Wikifolio.<anonymous> (C:\Users\XXX\Desktop\wikifolio\src\models\Wikifolio.ts:649:27)
    at step (C:\Users\XXX\Desktop\wikifolio\src\models\Wikifolio.ts:44:23)
    at Object.next (C:\Users\XXX\Desktop\wikifolio\src\models\Wikifolio.ts:25:53)
    at fulfilled (C:\Users\XXX\Desktop\wikifolio\src\models\Wikifolio.ts:16:58)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
```