### PR TITLE
Set todaysFirstTick to null if it is null

### DIFF
--- a/src/models/Wikifolio.ts
+++ b/src/models/Wikifolio.ts
@@ -646,7 +646,7 @@ export class Wikifolio {
 			data.dates = data.timestamps.map(ts => toDate(ts))
 			data.creationDate = toDate(data.creationDate)
 			data.publishDate = toDate(data.publishDate)
-			data.todaysFirstTick = !data.todaysFirstTick ?? toDate(data.todaysFirstTick)
+			data.todaysFirstTick = data.todaysFirstTick === null ? data.todaysFirstTick : toDate(data.todaysFirstTick)
 		}
 
 		return data


### PR DESCRIPTION
In my previous PR #8, in the Wikifolio.ts file, I made this change:

```diff
- data.todaysFirstTick = toDate(data.todaysFirstTick)
+ data.todaysFirstTick = !data.todaysFirstTick ?? toDate(data.todaysFirstTick)
```
This fixes the error ```TypeError: Cannot read property 'includes' of null``` but also sets todaysFirstTick to true because of !data.todaysFirstTick what makes not really sense because the 'real' value is still null.